### PR TITLE
Increase memory to 2G

### DIFF
--- a/etc/che-plugin.yaml
+++ b/etc/che-plugin.yaml
@@ -36,4 +36,4 @@ containers:
    ports:
        - exposedPort: 3000
        - exposedPort: 3030
-   memory-limit: "512M"
+   memory-limit: "2048M"


### PR DESCRIPTION
Currently che-theia runs jdt-ls and typescript ls. Current memory of 512Mi is not enough for typesript development. Imagine for Java... 

This PR is to increase memory to 2048M